### PR TITLE
Fix: Added top_p parameter to AgentConfig instances

### DIFF
--- a/nyuctf_multiagent/config.py
+++ b/nyuctf_multiagent/config.py
@@ -11,6 +11,7 @@ class AgentConfig:
     max_rounds: int
     model: str
     temperature: float
+    top_p: float
     max_tokens: int
     prompt: str
     toolset: list
@@ -29,6 +30,7 @@ class Config:
             max_rounds=self.config_yaml.get("planner", {}).get("max_rounds", 30),
             model=self.config_yaml.get("planner", {}).get("model", "gpt-4o-2024-11-20"),
             temperature=self.config_yaml.get("planner", {}).get("temperature", 0.95),
+            top_p=self.config_yaml.get("planner", {}).get("top_p", 1.0),
             max_tokens=self.config_yaml.get("planner", {}).get("max_tokens", 4096),
             prompt=self.config_yaml.get("planner", {}).get("prompt", "prompt/base_planner_prompt.yaml"),
             toolset=self.config_yaml.get("planner", {}).get("toolset", ["run_command", "submit_flag", "giveup", "delegate"]),
@@ -39,6 +41,7 @@ class Config:
             max_rounds=self.config_yaml.get("executor", {}).get("max_rounds", 30),
             model=self.config_yaml.get("executor", {}).get("model", "gpt-4o-2024-11-20"),
             temperature=self.config_yaml.get("executor", {}).get("temperature", 0.95),
+            top_p=self.config_yaml.get("executor", {}).get("top_p", 1.0),
             max_tokens=self.config_yaml.get("executor", {}).get("max_tokens", 4096),
             len_observations=self.config_yaml.get("executor", {}).get("len_observations", 5),
             prompt=self.config_yaml.get("executor", {}).get("prompt", "prompt/base_executor_prompt.yaml"),
@@ -50,6 +53,7 @@ class Config:
             max_rounds=self.config_yaml.get("autoprompter", {}).get("max_rounds", 30),
             model=self.config_yaml.get("autoprompter", {}).get("model", "gpt-4o-2024-11-20"),
             temperature=self.config_yaml.get("autoprompter", {}).get("temperature", 0.95),
+            top_p=self.config_yaml.get("autoprompter", {}).get("top_p", 1.0),
             max_tokens=self.config_yaml.get("autoprompter", {}).get("max_tokens", 4096),
             prompt=self.config_yaml.get("autoprompter", {}).get("prompt", "prompt/autoprompt_prompt.yaml"),
             toolset=self.config_yaml.get("autoprompter", {}).get("toolset", ["run_command", "generate_prompt"]),


### PR DESCRIPTION
I encountered an `AttributeError` encountered when running `run_dcipher.py` like:

```bash
python3 run_dcipher.py --split test --challenge <random-challenge>
```

### Issue:

The error occurred because the `AgentConfig` class did not have a `top_p` attribute. The traceback provided is as follows:

```
Traceback (most recent call last):
  ...
AttributeError: 'AgentConfig' object has no attribute 'top_p'
...
ValueError: Parameter did not exist 'planner.top_p'
```

### Solution:

To resolve this issue, I've added the `top_p` parameter to all instances of the `AgentConfig` class—`planner`, `executor`, and `autoprompter`. This parameter is initialized from the configuration files.

### Changes Made:

**AgentConfig Dataclass**: 
   - Added `top_p: float` attribute.

**Config Class**:
   - Updated initialization of `planner`, `executor`, and `autoprompter` to include the `top_p` parameter using:
     ```python
     top_p=self.config_yaml.get("<role>", {}).get("top_p", 1.0)
     ```
Let me know if there are further modifications required. Thanks!